### PR TITLE
Show hours also on users stat page, total time card

### DIFF
--- a/frontend/src/components/user-stats-cards/UserStatsCards.tsx
+++ b/frontend/src/components/user-stats-cards/UserStatsCards.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import { gql } from '@urql/core';
 import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
@@ -8,8 +8,8 @@ import {
   dateDiffToAgoString,
   dateDiffToString,
   formatDate,
-  isToday,
   prettyFromSeconds,
+  prettyHoursFromSeconds,
   secondsToMinutesOrHours,
   timeBetween,
   timeSince,
@@ -63,7 +63,16 @@ const UserStatsCards = ({ user }: Props) => {
       <div className={styles.userStatsCardsWrapper}>
         <UserStatsCard title="Last session" content={getLastSessionText(user.recentSessions)} />
         <UserStatsCard title="Today" content={getTodayText(user.timeTodaySeconds)} />
-        <UserStatsCard title="Total time" content={prettyFromSeconds(user.totalTimeSeconds)} />
+        <UserStatsCard
+          title="Total time"
+          content={
+            <>
+              {prettyFromSeconds(user.totalTimeSeconds)}
+              <br />
+              {`(${prettyHoursFromSeconds(user.totalTimeSeconds)})`}
+            </>
+          }
+        />
         <UserStatsCard title="Longest session" content={prettyFromSeconds(longestSessionSeconds)} />
       </div>
       <div className={styles.graphContainer}>
@@ -100,7 +109,7 @@ const UserStatsCards = ({ user }: Props) => {
 
 interface UserStatCardProps {
   title: string;
-  content: string;
+  content: string | ReactElement;
 }
 
 const UserStatsCard = ({ title, content }: UserStatCardProps) => (

--- a/frontend/src/dateUtil.ts
+++ b/frontend/src/dateUtil.ts
@@ -64,19 +64,19 @@ export function formatDate(date: Date): string {
 }
 
 export function prettyFromSeconds(seconds: number) {
-  let pretty = `${seconds % 60}s`;
-  if (seconds >= 60) {
-    const minutes = Math.floor(seconds / 60) % 60;
+  let pretty = `${seconds % SECONDS_PER_MINUTE}s`;
+  if (seconds >= SECONDS_PER_MINUTE) {
+    const minutes = Math.floor(seconds / SECONDS_PER_MINUTE) % SECONDS_PER_MINUTE;
     pretty = `${minutes}m ${pretty}`;
   }
 
-  if (seconds >= 60 * 60) {
-    const hours = Math.floor(seconds / 60 / 60) % 24;
+  if (seconds >= SECONDS_PER_MINUTE * MINUTES_PER_HOUR) {
+    const hours = Math.floor(seconds / SECONDS_PER_MINUTE / MINUTES_PER_HOUR) % HOURS_PER_DAY;
     pretty = `${hours}h ${pretty}`;
   }
 
-  if (seconds >= 60 * 60 * 24) {
-    const days = Math.floor(seconds / 60 / 60 / 24);
+  if (seconds >= SECONDS_PER_MINUTE * MINUTES_PER_HOUR * HOURS_PER_DAY) {
+    const days = Math.floor(seconds / SECONDS_PER_MINUTE / MINUTES_PER_HOUR / HOURS_PER_DAY);
     pretty = `${days}d ${pretty}`;
   }
 
@@ -111,4 +111,19 @@ export function secondsToMinutesOrHours(seconds: number) {
 
   const hours = Math.floor(minutes / MINUTES_PER_HOUR);
   return `${hours} hours`;
+}
+
+export function prettyHoursFromSeconds(seconds: number) {
+  let pretty = `${seconds % SECONDS_PER_MINUTE}s`;
+  if (seconds >= SECONDS_PER_MINUTE) {
+    const minutes = Math.floor(seconds / SECONDS_PER_MINUTE) % SECONDS_PER_MINUTE;
+    pretty = `${minutes}m ${pretty}`;
+  }
+
+  if (seconds >= SECONDS_PER_MINUTE * MINUTES_PER_HOUR) {
+    const hours = Math.floor(seconds / SECONDS_PER_MINUTE / MINUTES_PER_HOUR);
+    pretty = `${hours}h ${pretty}`;
+  }
+
+  return pretty;
 }

--- a/frontend/src/util.ts
+++ b/frontend/src/util.ts
@@ -123,8 +123,6 @@ export const formatNick = (cid: string, nick: string) => {
       return `🌀 ${nick} 🌀`;
     case 'davidm':
       return `👑 ${nick} 🔧`;
-    case 'axellars':
-      return `😈 ${nick} 😈`;
     default:
       return nick;
   }

--- a/frontend/src/util.ts
+++ b/frontend/src/util.ts
@@ -123,6 +123,8 @@ export const formatNick = (cid: string, nick: string) => {
       return `🌀 ${nick} 🌀`;
     case 'davidm':
       return `👑 ${nick} 🔧`;
+    case 'axellars':
+      return `😈 ${nick} 😈`;
     default:
       return nick;
   }


### PR DESCRIPTION
Added the second row: 
![image](https://user-images.githubusercontent.com/16452604/138525429-d6790d21-0280-4f94-a6b8-5da856ef2fe4.png)

Was requested as it simplifies some comparisons and also is what is used for the all-time stats.