### PR TITLE
Simplified setup of backend slightly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ load_gamma: gamma.sql
 create_gamma_client:
 	echo "INSERT INTO internal_text (id, sv, en) VALUES ('dc989ea3-c80b-4fbf-97d3-dbb6869cdd26', 'hubbit', 'hubbit')" | docker exec -i hubbit2-gamma-db-1 psql -U gamma gamma
 	echo "INSERT INTO itclient (id, client_id, client_secret, web_server_redirect_uri, access_token_validity, refresh_token_validity, auto_approve, name, description) VALUES ('714ee306-e904-4978-bb2b-cd1a3478062c', 'hubbit', '{noop}hubbit', 'http://localhost:3000/api/auth/gamma/callback', 3600, 500000000, true, 'hubbit', 'dc989ea3-c80b-4fbf-97d3-dbb6869cdd26')"  | docker exec -i hubbit2-gamma-db-1 psql -U gamma gamma
-	echo "INSERT INTO apikey (id, name, description, key) VALUES ('c0f26d1b-9e70-4218-bb58-62ba2da72ce5', 'hubbit', 'dc989ea3-c80b-4fbf-97d3-dbb6869cdd26', 'hubbit')"  | docker exec -i hubbit2-gamma-db-1 psql -U gamma gamma 
+	echo "INSERT INTO apikey (id, name, description, key) VALUES ('c0f26d1b-9e70-4218-bb58-62ba2da72ce5', 'hubbit', 'dc989ea3-c80b-4fbf-97d3-dbb6869cdd26', 'hubbit')"  | docker exec -i hubbit2-gamma-db-1 psql -U gamma gamma
 
 setup_gamma: load_gamma create_gamma_client
 
@@ -17,3 +17,5 @@ setup_hubbit:
 	cd backend && cargo sqlx migrate run
 
 setup: setup_gamma setup_hubbit
+
+setup_client: create_gamma_client

--- a/backend/dev.Dockerfile
+++ b/backend/dev.Dockerfile
@@ -2,7 +2,7 @@ FROM rust
 
 ENV TZ=Europe/Stockholm
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update && apt install -y tzdata
+RUN apt update && apt install -y tzdata postgresql-13
 
 WORKDIR /app
 

--- a/backend/wait-for-postgres.sh
+++ b/backend/wait-for-postgres.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# wait-for-postgres.sh
+
+set -e
+
+host="$1"
+password="$2"
+user="$3"
+shift 3
+
+echo "Pass: $password || psql -h $host -U $user -c '\q'"
+
+until PGPASSWORD=$password psql -h "$host" -U $user -c '\q'; do
+  >&2 echo "Postgres is unavailable - sleeping"
+  sleep 1
+done
+
+>&2 echo "Postgres is up - executing command"
+exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,9 @@ services:
     volumes:
       - ./backend:/app
       - /app/target
+    depends_on:
+      - "hubbit-db"
+    command: ["./wait-for-postgres.sh", "hubbit-db", "${PG_PASSWORD}", "${PG_USERNAME}", "sh", "-c", "cargo sqlx migrate run && cargo watch -x run"]
 
   hubbit-db:
     image: postgres:13.2


### PR DESCRIPTION
Add make command setup_client to only create gamma client.
Now also ensures that the backend doesn't start before the db.