### PR TITLE
Remove unnecessary casts, simplify map operations

### DIFF
--- a/backend/src/schema/stats.rs
+++ b/backend/src/schema/stats.rs
@@ -258,7 +258,7 @@ impl StatsQuery {
       (input.year, input.month)
     } else {
       let now = Utc::now();
-      (now.year() as i32, now.month() as i32)
+      (now.year(), now.month() as i32)
     };
 
     let stats_service = context.data_unchecked::<StatsService>();
@@ -316,7 +316,7 @@ impl StatsQuery {
       (input.year, input.week)
     } else {
       let now = Utc::now();
-      (now.year() as i32, now.iso_week().week() as i32)
+      (now.year(), now.iso_week().week() as i32)
     };
 
     let stats_service = context.data_unchecked::<StatsService>();
@@ -334,7 +334,7 @@ impl StatsQuery {
 
     let previous_stats = if context.look_ahead().field("prevPosition").exists() {
       stats_service
-        .get_week(prev_week.year(), prev_week.iso_week().week() as u32)
+        .get_week(prev_week.year(), prev_week.iso_week().week())
         .await
         .ok()
     } else {
@@ -368,7 +368,7 @@ impl StatsQuery {
       (input.year, input.month, input.day)
     } else {
       let now = Utc::now();
-      (now.year() as i32, now.month() as i32, now.day() as i32)
+      (now.year(), now.month() as i32, now.day() as i32)
     };
 
     let stats_service = context.data_unchecked::<StatsService>();
@@ -454,7 +454,7 @@ fn sort_and_map_stats(
     HashMap::new()
   };
 
-  let mut stats = stats.into_iter().map(|(_, stat)| stat).collect::<Vec<_>>();
+  let mut stats = stats.into_values().collect::<Vec<_>>();
   stats.sort_by_key(|stat| -stat.duration_ms);
   stats
     .iter()
@@ -463,7 +463,7 @@ fn sort_and_map_stats(
       user: User { id: stat.user_id },
       duration_seconds: stat.duration_ms / 1000,
       current_position: index as i32 + 1,
-      prev_position: prev_positions.get(&stat.user_id).map(|&v| v as i32),
+      prev_position: prev_positions.get(&stat.user_id).copied(),
     })
     .collect()
 }

--- a/backend/src/services/stats/util.rs
+++ b/backend/src/services/stats/util.rs
@@ -74,7 +74,7 @@ pub fn year_time_bounds(year: i32) -> (DateTime<Local>, DateTime<Local>) {
 }
 
 pub fn month_time_bounds(year: i32, month: u32) -> (DateTime<Local>, DateTime<Local>) {
-  let start_time = Local.ymd(year, month as u32, 1).and_hms(0, 0, 0);
+  let start_time = Local.ymd(year, month, 1).and_hms(0, 0, 0);
   let end_time = if month == 12 {
     Local.ymd(year + 1, 1, 1).and_hms(23, 59, 59)
   } else {
@@ -90,11 +90,11 @@ pub fn day_time_bounds(year: i32, month: u32, day: u32) -> (DateTime<Local>, Dat
 }
 
 pub fn month_date_bounds(year: i32, month: u32) -> (NaiveDate, NaiveDate) {
-  let start_time = Local.ymd(year, month as u32, 1).naive_local();
+  let start_time = Local.ymd(year, month, 1).naive_local();
   let end_time = if month == 12 {
     Local.ymd(year + 1, 1, 1).and_hms(23, 59, 59)
   } else {
-    Local.ymd(year, month as u32 + 1, 1).and_hms(0, 0, 0)
+    Local.ymd(year, month + 1, 1).and_hms(0, 0, 0)
   } - Duration::seconds(1);
   let end_time = end_time.date().naive_local();
   (start_time, end_time)
@@ -108,6 +108,6 @@ pub fn week_date_bounds(year: i32, week: u32) -> (NaiveDate, NaiveDate) {
 
 pub fn day_date_bounds(year: i32, month: u32, day: u32) -> (NaiveDate, NaiveDate) {
   let start_time = Local.ymd(year, month, day).naive_local();
-  let end_time = Local.ymd(year, month as u32, day as u32).naive_local();
+  let end_time = Local.ymd(year, month, day).naive_local();
   (start_time, end_time)
 }


### PR DESCRIPTION
This fixes errors during the `lint` stage of the `backend` workflow.