### PR TITLE
Fix frontend Docker build and CI

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
       - name: Install dependencies
         run: yarn --frozen-lockfile
         working-directory: frontend
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
       - name: Install dependencies
         run: yarn --frozen-lockfile
         working-directory: frontend
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
       - name: Install dependencies
         run: yarn --frozen-lockfile
         working-directory: frontend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,7 +14,7 @@ RUN yarn install --frozen-lockfile
 
 
 
-FROM node:lts-alpine as BUILD_IMAGE
+FROM node:16-alpine as BUILD_IMAGE
 
 WORKDIR /app
 
@@ -27,7 +27,7 @@ RUN yarn install --production --frozen-lockfile --ignore-scripts --prefer-offlin
 
 
 
-FROM node:lts-alpine
+FROM node:16-alpine
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
The frontend will fail to build on node v17+ as it uses an old version of NextJS that in turn in dependent on other packages that use deprecated node features and contains several vulnerabilities.

This fix will allow the backend to build by changing the build process to use node 16 but the "proper" fix would be to update NextJS. However from what I found that leads to some dependency issues that need to be resolved.