### PR TITLE
Update rust version to 1.70

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 ##################
 ### BASE STAGE ###
 ##################
-FROM rust:1.60 as base
+FROM rust:1.70 as base
 
 ENV TZ=Europe/Stockholm
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Update rust version used in the backend Dockerfile to allow it to build successfully.

Without this change the build fails when installing sqlx-cli with the following error:
```
error: failed to compile `sqlx-cli v0.5.13`, intermediate artifacts can be found at `/tmp/cargo-installAca0Fp`
Caused by:
  package `socket2 v0.5.3` cannot be built because it requires rustc 1.63 or newer, while the currently active rustc version is 1.60.0
```